### PR TITLE
Update puppet scripts for MI 4.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository contains the Puppet modules for WSO2 Micro Integrator.
     ```bash
     sudo puppet module install puppetlabs-java
     ```
-5. Download and update wso2mi-4.4.0 pack. Then copy it to the `<puppet_environment>/modules/micro_integrator/files` as `wso2mi-4.4.0.zip` directory.
+5. Download and update wso2mi-4.5.0 pack. Then copy it to the `<puppet_environment>/modules/micro_integrator/files` as `wso2mi-4.5.0.zip` directory.
 6. [Optional] Download and update wso2-integration-control-plane-1.1.0 pack. Then copy it to the `<puppet_environment>/modules/integration_control_plane/files` as `integration-control-plane-1.1.0.zip` directory.
 
 ### Setting up the Puppet Agents

--- a/modules/micro_integrator/manifests/params.pp
+++ b/modules/micro_integrator/manifests/params.pp
@@ -27,7 +27,7 @@ class micro_integrator::params {
 
   # Product basics
   $product         = 'wso2mi'
-  $product_version = '4.4.0'
+  $product_version = '4.5.0'
   $service_name    = $product        # systemd unit name
 
   # Templates inside the ZIP


### PR DESCRIPTION
## Purpose
$title

fixes: https://github.com/wso2/product-micro-integrator/issues/4384

**Tested with WSO2 Micro Integrator 4.5.0-Alpha pack from https://github.com/wso2/product-micro-integrator/releases/download/v4.5.0-alpha/wso2mi-4.5.0-alpha.zip**

<img width="884" height="318" alt="Screenshot 2025-10-08 at 23 08 08" src="https://github.com/user-attachments/assets/1872476f-9418-45f7-8671-f019d789f351" />
<img width="863" height="325" alt="Screenshot 2025-10-08 at 23 06 14" src="https://github.com/user-attachments/assets/71ff24b6-2835-4640-b022-db47667d9592" />


Temporarily updated params.pp in the scripts to use 4.5.0-alpha, didn't push this change to PR
<img width="797" height="126" alt="Screenshot 2025-10-08 at 23 03 40" src="https://github.com/user-attachments/assets/101c316f-d3fa-4323-9e81-4f3d91a04fcc" />

