### PR TITLE
Update puppet scripts for MI 4.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ This repository contains the Puppet modules for WSO2 Micro Integrator.
     ```bash
     sudo puppet module install puppetlabs-java
     ```
-5. Download and update wso2mi-4.5.0 pack. Then copy it to the `<puppet_environment>/modules/micro_integrator/files` as `wso2mi-4.5.0.zip` directory.
-6. [Optional] Download and update wso2-integration-control-plane-1.2.0 pack. Then copy it to the `<puppet_environment>/modules/integration_control_plane/files` as `integration-control-plane-1.2.0.zip` directory.
+5. Download and update wso2mi-4.6.0 pack. Then copy it to the `<puppet_environment>/modules/micro_integrator/files` as `wso2mi-4.6.0.zip` directory.
+6. [Optional] Download and update wso2-integration-control-plane-2.0.0 pack. Then copy it to the `<puppet_environment>/modules/integration_control_plane/files` as `integration-control-plane-2.0.0.zip` directory.
 
 ### Setting up the Puppet Agents
 1. Install and configure your puppet agents with your puppet server. [Guide](https://www.puppet.com/docs/puppet/7/install_agents#install_agents)

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -25,7 +25,7 @@ Stage['main'] -> Stage['custom'] -> Stage['final']
 
 node default {
   class { 'java':
-    package => 'openjdk-11-jdk',
+    package => 'openjdk-25-jdk',
   }
   class { "::${::profile}": }
   class { "::${::profile}::custom":

--- a/modules/micro_integrator/manifests/params.pp
+++ b/modules/micro_integrator/manifests/params.pp
@@ -27,7 +27,7 @@ class micro_integrator::params {
 
   # Product basics
   $product         = 'wso2mi'
-  $product_version = '4.5.0'
+  $product_version = '4.6.0'
   $service_name    = $product        # systemd unit name
 
   # Templates inside the ZIP

--- a/modules/micro_integrator/templates/mi-home/bin/micro-integrator.sh.erb
+++ b/modules/micro_integrator/templates/mi-home/bin/micro-integrator.sh.erb
@@ -121,6 +121,38 @@ if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
 fi
 
 # ----- Process the input command ----------------------------------------------
+
+# Function to export variables from the given .env file
+export_env_file() {
+  local file_path="$1"
+
+  # Check if the file exists
+  if [ ! -f "$file_path" ]; then
+    echo "Error: File '$file_path' not found."
+    return 1  # Return with an error status
+  fi
+
+  # Read the .env file and export each variable to the environment
+  while IFS='=' read -r key value; do
+      # Ignore lines starting with '#' (comments) or empty lines
+      case "$key" in
+          \#*|"")
+              # Skip comments or empty lines
+              continue
+              ;;
+          *)
+              # Trim surrounding whitespace from key and value
+              key=$(echo "$key" | xargs)
+              value=$(echo "$value" | xargs)
+              # Export the key-value pair to the environment
+              export "$key=$value"
+              ;;
+      esac
+  done < "$file_path"
+
+  echo "Environment variables loaded from $file_path."
+}
+
 args=""
 for c in $*
 do
@@ -145,6 +177,16 @@ do
     else
         args="$args $c"
     fi
+    # Check if the argument starts with --env-file=
+    case "$c" in
+      --env-file=*)
+        file_path="${c#--env-file=}"
+        export_env_file "$file_path"
+        ;;
+      *)
+        continue
+        ;;
+    esac
 done
 
 if [ "$ARGUMENT" = "car" ]; then
@@ -160,7 +202,7 @@ if [ "$CMD" = "--debug" ]; then
     echo "Warning !!!. User specified JAVA_OPTS will be ignored, once you give the --debug option."
   fi
   CMD="RUN"
-  JAVA_OPTS="-Xdebug -Xnoagent -Djava.compiler=NONE -Xrunjdwp:transport=dt_socket,server=y,suspend=y,address=$PORT"
+  JAVA_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=*:$PORT"
   echo "Please start the remote debugging client to continue..."
 elif [ "$CMD" = "start" ]; then
   if [ -e "$CARBON_HOME/wso2carbon.pid" ]; then
@@ -202,9 +244,9 @@ fi
 # ---------- Handle the SSL Issue with proper JDK version --------------------
 java_version=$("$JAVACMD" -version 2>&1 | awk -F '"' '/version/ {print $2}')
 java_version_formatted=$(echo "$java_version" | awk -F. '{printf("%02d%02d",$1,$2);}')
-if [ $java_version_formatted -lt 1100 ] || [ $java_version_formatted -gt 1700 ]; then
+if [ $java_version_formatted -lt 2100 ] || [ $java_version_formatted -gt 2500 ]; then
    echo " Starting WSO2 MI (in unsupported JDK)"
-   echo " [ERROR] WSO2 MI is supported only between JDK 11 and JDK 17"
+   echo " [ERROR] WSO2 MI is supported only between JDK 21 and JDK 25"
    exit 0
 fi
 
@@ -283,8 +325,23 @@ fi
 JAVA_VER_BASED_OPTS=""
 
 if [ $java_version_formatted -ge 1100 ]; then
-    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED"
+    JAVA_VER_BASED_OPTS="--add-opens=java.base/java.io=ALL-UNNAMED --add-opens=java.xml/com.sun.org.apache.xerces.internal.util=ALL-UNNAMED --add-exports=java.naming/com.sun.jndi.ldap=ALL-UNNAMED --add-opens=java.base/java.net=ALL-UNNAMED --add-opens=java.base/java.lang=ALL-UNNAMED --add-opens java.rmi/sun.rmi.transport=ALL-UNNAMED --add-opens=java.management/sun.management=ALL-UNNAMED --add-exports=jdk.naming.dns/com.sun.jndi.dns=ALL-UNNAMED"
 fi
+
+if [ $java_version_formatted -ge 2400 ]; then
+    JAVA_VER_BASED_OPTS="$JAVA_VER_BASED_OPTS --sun-misc-unsafe-memory-access=allow"
+fi
+
+# start diagnostic tool in background in diagnostic-tool/bin/diagnostic
+"$CARBON_HOME"/diagnostics-tool/bin/diagnostics.sh &
+diagnostic_tool_pid=$!
+
+# trap signals so we can shutdown the diagnostic tool
+cleanup() {
+    kill "$diagnostic_tool_pid"
+}
+trap 'cleanup' EXIT INT
+
 
 while [ "$status" = "$START_EXIT_STATUS" ]
 do
@@ -342,8 +399,11 @@ do
     -DenableReadinessProbe=true \
     -DenableLivenessProbe=true \
     -DenableManagementApi=true \
+    -DenableICPApi=true \
     -DskipStartupExtensions=false \
     -Dautomation.mode.seq.car.name="$CAR_NAME" \
+    -Dpolyglot.engine.WarnInterpreterOnly=false \
+    -Dpolyglot.js.ecmascript-version=2022 \
     -Dlog4j2.contextSelector=org.apache.logging.log4j.core.async.AsyncLoggerContextSelector \
     -Dorg.ops4j.pax.logging.logReaderEnabled=false \
     -Dorg.ops4j.pax.logging.eventAdminEnabled=false \


### PR DESCRIPTION
## Purpose
> Update puppet scripts for MI 4.6.0

Tested with WSO2 Micro Integrator 4.6.0-Alpha pack from https://github.com/wso2/product-micro-integrator/releases/tag/v4.6.0-alpha

Related issue: https://github.com/wso2/product-micro-integrator/issues/4746

<img width="1511" height="644" alt="Screenshot 2026-03-25 at 12 52 03" src="https://github.com/user-attachments/assets/d0d62335-b5fe-4b1d-94a8-42c84e764951" />

